### PR TITLE
set_cpuclock is no longer tied to emu launching

### DIFF
--- a/Apps/EmuClean/launch.sh
+++ b/Apps/EmuClean/launch.sh
@@ -2,7 +2,11 @@
 # Refresh icon by Icons8
 # https://icons8.com/icon/59872/refresh
 
+. /mnt/SDCARD/System/bin/helpers.sh
+
 EMU_DIR="/mnt/SDCARD/Emus"
+
+set_cpuclock "performance"
 
 for EMU in "$EMU_DIR"/*; do
     if [ -d "$EMU" ]; then
@@ -19,3 +23,5 @@ for EMU in "$EMU_DIR"/*; do
         fi
     fi
 done
+
+CPU_MIN_FREQ=816000 set_cpuclock "smart" # reset cpu clock

--- a/System/bin/helpers.sh
+++ b/System/bin/helpers.sh
@@ -7,7 +7,7 @@ set_cpuclock() {
     chmod a+w /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
 
     case $1 in
-        "smart"|*)
+        "smart")
             echo conservative > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
             echo 50 >/sys/devices/system/cpu/cpufreq/conservative/down_threshold
             echo 80 >/sys/devices/system/cpu/cpufreq/conservative/up_threshold

--- a/System/bin/helpers.sh
+++ b/System/bin/helpers.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Helper functions for Quark
+
+set_cpuclock() {
+    chmod a+w /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+    chmod a+w /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
+    chmod a+w /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+
+    case $1 in
+        "smart"|*)
+            echo conservative > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+            echo 50 >/sys/devices/system/cpu/cpufreq/conservative/down_threshold
+            echo 80 >/sys/devices/system/cpu/cpufreq/conservative/up_threshold
+            echo 3 >/sys/devices/system/cpu/cpufreq/conservative/freq_step
+            echo 1 >/sys/devices/system/cpu/cpufreq/conservative/sampling_down_factor
+            echo 400000 >/sys/devices/system/cpu/cpufreq/conservative/sampling_rate
+            echo "$CPU_MIN_FREQ" > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
+            echo 1344000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+            ;;
+        "performance")
+            echo performance > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+            echo 1344000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+            ;;
+        "overclock")
+            echo performance > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+            echo 1536000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+            ;;
+    esac
+
+    chmod a-w /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+    chmod a-w /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
+    chmod a-w /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+}


### PR DESCRIPTION
Now can be used in other applications (i.e. emuclean)
Launching games in smart mode will initially launch in performance mode for 5 seconds to speed up game launching before setting to smart