### PR TITLE
Add working quicksave for RA/DraStic

### DIFF
--- a/Emus/.emu_setup/launch_emu.sh
+++ b/Emus/.emu_setup/launch_emu.sh
@@ -131,3 +131,8 @@ case "$EMU" in
 esac
 
 set_cpuclock --mode smart # reset cpu clock
+
+if [ -f "/tmp/.quicksave" ]; then
+    log_message "Displaying quicksave screen from launch_emu!" "/mnt/SDCARD/System/log/quicksave.log"
+    display -t "It's now safe to turn off your Smart" > /mnt/SDCARD/display.log 2>&1
+fi

--- a/System/scripts/quicksave.sh
+++ b/System/scripts/quicksave.sh
@@ -8,7 +8,7 @@ SAVED_CMD_TO_RUN="/mnt/SDCARD/Saves/.quicksave.sh"
 
 if grep -q "/mnt/SDCARD/Emus" /tmp/cmd_to_run.sh; then
   cp /tmp/cmd_to_run.sh "$SAVED_CMD_TO_RUN"
-  kill_cmd_to_run
+  touch /tmp/.quicksave
+  killall ra32.trimui ra32.trimui_sdl drastic
   sync
-  display -t "It's now safe to turn off your Smart"
 fi

--- a/System/scripts/quicksave.sh
+++ b/System/scripts/quicksave.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+SAVED_CMD_TO_RUN="/mnt/SDCARD/Saves/.quicksave.sh"
+
+. /mnt/SDCARD/System/scripts/helpers.sh
+
+if grep -q "/mnt/SDCARD/Emus" /tmp/cmd_to_run.sh; then
+  cp /tmp/cmd_to_run.sh "$SAVED_CMD_TO_RUN"
+  kill_cmd_to_run
+  sync
+  display -t "It's now safe to turn off your Smart"
+fi

--- a/System/scripts/quicksave.sh
+++ b/System/scripts/quicksave.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# alternative to MENU Force Save
+# relies on auto save/load state
 
 SAVED_CMD_TO_RUN="/mnt/SDCARD/Saves/.quicksave.sh"
 

--- a/System/starts/7-evtest-hotkeys.sh
+++ b/System/starts/7-evtest-hotkeys.sh
@@ -94,7 +94,7 @@ quicksave_hotkey() {
         esac
 
         if $SELECT_PRESSED && $MENU_L_PRESSED; then
-            /bin/sh /mnt/SDCARD/System/scripts/quicksave.sh
+            /mnt/SDCARD/System/scripts/quicksave.sh
         fi
     done
 }

--- a/System/starts/7-evtest-hotkeys.sh
+++ b/System/starts/7-evtest-hotkeys.sh
@@ -81,5 +81,24 @@ screenshot_hotkey() {
     done
 }
 
+quicksave_hotkey() {
+    SELECT_PRESSED=false
+    MENU_L_PRESSED=false
+
+    evtest /dev/input/event0 | while read line; do
+        case "$line" in
+            *"EV_KEY"*"KEY_RIGHTCTRL"*"value 1") SELECT_PRESSED=true ;;
+            *"EV_KEY"*"KEY_RIGHTCTRL"*"value 0") SELECT_PRESSED=false ;;
+            *"EV_KEY"*"KEY_PAGEUP"*"value 1") MENU_L_PRESSED=true ;;
+            *"EV_KEY"*"KEY_PAGEUP"*"value 0") MENU_L_PRESSED=false ;;
+        esac
+
+        if $SELECT_PRESSED && $MENU_L_PRESSED; then
+            /bin/sh /mnt/SDCARD/System/scripts/quicksave.sh
+        fi
+    done
+}
+
 reboot_hotkey &
 screenshot_hotkey &
+quicksave_hotkey &

--- a/System/trimui/bin/MainUI
+++ b/System/trimui/bin/MainUI
@@ -10,7 +10,7 @@ QUICKSAVE_CMD_TO_RUN="/mnt/SDCARD/Saves/.quicksave.sh"
 
 if [ -f "$QUICKSAVE_CMD_TO_RUN" ]; then
     mv "$QUICKSAVE_CMD_TO_RUN" /tmp/cmd_to_run.sh
-    /bin/sh "$QUICKSAVE_CMD_TO_RUN"
+    /bin/sh /tmp/cmd_to_run.sh
 fi
 
 /mnt/SDCARD/System/trimui/bin/MainUI.bin # hand over to MainUI as normal

--- a/System/trimui/bin/MainUI
+++ b/System/trimui/bin/MainUI
@@ -14,3 +14,4 @@ if [ -f "$QUICKSAVE_CMD_TO_RUN" ]; then
 fi
 
 /mnt/SDCARD/System/trimui/bin/MainUI.bin # hand over to MainUI as normal
+

--- a/System/trimui/bin/MainUI
+++ b/System/trimui/bin/MainUI
@@ -1,9 +1,16 @@
 #!/bin/sh
 
+QUICKSAVE_CMD_TO_RUN="/mnt/SDCARD/Saves/.quicksave.sh"
+
 {
     echo "2-1" > /sys/bus/usb/drivers/usb/unbind # "detach" the USB-C audio device
     sleep 1
     echo "2-1" > /sys/bus/usb/drivers/usb/bind # re-attach USB-C audio after MainUI has a chance to initialise the audio subsystem
 } &
+
+if [ -f "$QUICKSAVE_CMD_TO_RUN" ]; then
+    /bin/sh "$QUICKSAVE_CMD_TO_RUN"
+    rm -f "$QUICKSAVE_CMD_TO_RUN"
+fi
 
 /mnt/SDCARD/System/trimui/bin/MainUI.bin # hand over to MainUI as normal

--- a/System/trimui/bin/MainUI
+++ b/System/trimui/bin/MainUI
@@ -11,9 +11,7 @@ QUICKSAVE_LOG="/mnt/SDCARD/System/log/quicksave.log"
     echo "2-1" > /sys/bus/usb/drivers/usb/bind # re-attach USB-C audio after MainUI has a chance to initialise the audio subsystem
 } &
 
-if [ -f "/tmp/.quicksave" ]; then
-    display -t "It's now safe to turn off your Smart"
-elif [ -f "$QUICKSAVE_CMD_TO_RUN" ]; then
+if [ -f "$QUICKSAVE_CMD_TO_RUN" ] && ! [ -f "/tmp/.quicksave" ]; then
     mv "$QUICKSAVE_CMD_TO_RUN" /tmp/cmd_to_run.sh
     /tmp/cmd_to_run.sh
 fi

--- a/System/trimui/bin/MainUI
+++ b/System/trimui/bin/MainUI
@@ -1,6 +1,9 @@
 #!/bin/sh
 
+. /mnt/SDCARD/System/scripts/helpers.sh
+
 QUICKSAVE_CMD_TO_RUN="/mnt/SDCARD/Saves/.quicksave.sh"
+QUICKSAVE_LOG="/mnt/SDCARD/System/log/quicksave.log"
 
 {
     echo "2-1" > /sys/bus/usb/drivers/usb/unbind # "detach" the USB-C audio device
@@ -8,10 +11,11 @@ QUICKSAVE_CMD_TO_RUN="/mnt/SDCARD/Saves/.quicksave.sh"
     echo "2-1" > /sys/bus/usb/drivers/usb/bind # re-attach USB-C audio after MainUI has a chance to initialise the audio subsystem
 } &
 
-if [ -f "$QUICKSAVE_CMD_TO_RUN" ]; then
+if [ -f "/tmp/.quicksave" ]; then
+    display -t "It's now safe to turn off your Smart"
+elif [ -f "$QUICKSAVE_CMD_TO_RUN" ]; then
     mv "$QUICKSAVE_CMD_TO_RUN" /tmp/cmd_to_run.sh
-    /bin/sh /tmp/cmd_to_run.sh
+    /tmp/cmd_to_run.sh
 fi
 
 /mnt/SDCARD/System/trimui/bin/MainUI.bin # hand over to MainUI as normal
-

--- a/System/trimui/bin/MainUI
+++ b/System/trimui/bin/MainUI
@@ -9,8 +9,8 @@ QUICKSAVE_CMD_TO_RUN="/mnt/SDCARD/Saves/.quicksave.sh"
 } &
 
 if [ -f "$QUICKSAVE_CMD_TO_RUN" ]; then
+    mv "$QUICKSAVE_CMD_TO_RUN" /tmp/cmd_to_run.sh
     /bin/sh "$QUICKSAVE_CMD_TO_RUN"
-    rm -f "$QUICKSAVE_CMD_TO_RUN"
 fi
 
 /mnt/SDCARD/System/trimui/bin/MainUI.bin # hand over to MainUI as normal

--- a/System/trimui/bin/MainUI
+++ b/System/trimui/bin/MainUI
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-. /mnt/SDCARD/System/scripts/helpers.sh
-
 QUICKSAVE_CMD_TO_RUN="/mnt/SDCARD/Saves/.quicksave.sh"
 QUICKSAVE_LOG="/mnt/SDCARD/System/log/quicksave.log"
 


### PR DESCRIPTION
Press SELECT + MENU + L (might change this or?) to make a quick save, then manually power off your Smart. Power it back up again and it'll drop you right where you left off.  
Relies on auto save/load state setting in RetroArch/DraStic, will update DraStic gluon to support this later

Todo: regression test USB audio workaround