### PR TITLE
Add PCSX-ReARMed standalone emulator

### DIFF
--- a/static/Emus/.emu_setup/core_switch.sh
+++ b/static/Emus/.emu_setup/core_switch.sh
@@ -45,6 +45,12 @@ case "$EMU" in
             "fake08") NEW_CORE="native" DISPLAY="Core: Native" ;;
         esac
         ;;
+    "PS")
+        case "$CORE" in
+            "pcsx_rearmed-sa") NEW_CORE="pcsx_rearmed" DISPLAY="Core: Libretro" ;;
+            "pcsx_rearmed") NEW_CORE="pcsx_rearmed-sa" DISPLAY="Core: Standalone" ;;
+        esac
+        ;;
     "SFC")
         case "$CORE" in
             "chimerasnes") NEW_CORE="snes9x2005_plus" DISPLAY="Core: Snes9x-05+" ;;

--- a/static/Emus/.emu_setup/launch_emu.sh
+++ b/static/Emus/.emu_setup/launch_emu.sh
@@ -110,6 +110,18 @@ run_ffplay() {
     rm -f /tmp/stay_awake
 }
 
+run_pcsx() {
+    export HOME="$EMU_DIR"
+
+    PCSX_DIR="$EMU_DIR/pcsx"
+    export LD_LIBRARY_PATH="$PCSX_DIR/lib:$LD_LIBRARY_PATH"
+    export SDL_VIDEO_FBCON_ROTATION="CCW"
+
+    cd "$PCSX_DIR"
+
+    ./pcsx -cdfile "$ROM_FILE" > /mnt/SDCARD/PCSX.log 2>&1
+}
+
 ROM_FILE="$(readlink -f "$1")"
 
 if [ "$CPU_MODE" = "smart" ]; then
@@ -129,6 +141,12 @@ case "$EMU" in
     "PORTS") run_port ;;
     "PICO8") run_pico8 ;;
     "MEDIA"|"MP3") run_ffplay ;;
+    "PS")
+        case "$CORE" in
+            "pcsx_rearmed-sa") run_pcsx ;;
+            "pcsx_rearmed") run_retroarch ;;
+        esac
+        ;;
     *) run_retroarch ;;
 esac
 

--- a/static/Emus/PS/config.json
+++ b/static/Emus/PS/config.json
@@ -10,6 +10,10 @@
   "extlist": "cue|img|mdf|pbp|toc|cbn|m3u|chd",
   "launchlist": [
     {
+      "name": "Core: Libretro",
+      "launch": "/mnt/SDCARD/Emus/.emu_setup/core_switch.sh"
+    },
+    {
       "name": "CPU: Smart",
       "launch": "/mnt/SDCARD/Emus/.emu_setup/cpu_switch.sh"
     },

--- a/tasks/third_party.nims
+++ b/tasks/third_party.nims
@@ -106,7 +106,7 @@ task dufs, "Build dufs with cargo zigbuild":
   exec "cargo zigbuild --target armv7-unknown-linux-musleabihf --release"
 
 task thirdparty, "Build all third-party software":
-  for t in @["jq", "evtest", "dropbear", "gesftpserver", "dufs", "syncthing"]:
+  for t in @["jq", "evtest", "dropbear", "gesftpserver", "dufs", "syncthing", "buildPcsx"]:
     exec &"nimble {t} --verbose"
 
 task buildCores, "Build RetroArch cores using Docker":
@@ -125,10 +125,12 @@ task buildCores, "Build RetroArch cores using Docker":
 
   echo "Building cores: " & coreList
 
-  mkDir("dist/RetroArch/.retroarch/cores")
-  mkDir("dist/RetroArch/.retroarch/core_info")
+  if not dirExists("dist/RetroArch/.retroarch/cores"):
+    mkDir("dist/RetroArch/.retroarch/cores")
+  if not dirExists("dist/RetroArch/.retroarch/core_info"):
+    mkDir("dist/RetroArch/.retroarch/core_info")
 
-  let ccacheDir = getHomeDir() / ".ccache-retroarch"
+  let ccacheDir = getHomeDir() / ".ccache-quark"
   mkDir(ccacheDir)
 
   try:
@@ -142,3 +144,26 @@ task buildCores, "Build RetroArch cores using Docker":
     quit(1)
 
   echo "Cores built successfully"
+
+task buildPcsx, "Build PCSX ReARMed standalone using Docker":
+  if findExe("docker") == "":
+    echo "error: docker not found"
+    quit(1)
+
+  if not dirExists("dist/Emus/PS/pcsx"):
+    mkDir("dist/Emus/PS/pcsx")
+
+  let ccacheDir = getHomeDir() / ".ccache-quark"
+  mkDir(ccacheDir)
+
+  try:
+    exec "docker run --rm" &
+      " -e CORES=\"pcsx-sa\"" &
+      " -v \"$(pwd)/dist/Emus/PS/pcsx\":/output/pcsx" &
+      " -v \"" & ccacheDir & "\":/ccache" &
+      " ghcr.io/cobaltgit/quark-core-builder:latest"
+  except OSError as e:
+    echo "error: PCSX build failed"
+    quit(1)
+
+  echo "PCSX built successfully"


### PR DESCRIPTION
Additional option for PS1 emulation alongside the libretro core

Performs noticeably better than the libretro core in games such as Tekken 3
Running at 1344MHz CPU clock:
* ~55fps on libretro core, audio skipping without autoframeskip enabled
* Consistent 60fps on standalone emulator with headroom for slight fast forward

<img width="320" height="240" alt="Screenshot_19700101_014429" src="https://github.com/user-attachments/assets/db8800bd-dfaa-49b8-a0da-bbcb2f42c547" /> <img width="320" height="240" alt="Screenshot_19700101_014340" src="https://github.com/user-attachments/assets/6c86b83e-4e6e-4767-ad30-e4bea419e852" />
